### PR TITLE
Set up some minimal backend code

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+venv/
+database-dump.sql
+.env
+db

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,17 @@
+# Stage 2: Build the Python app
+FROM python:3.12-slim
+
+# Set the working directory for the Python app
+WORKDIR /cheminv
+
+# Copy and install Python dependencies
+COPY requirements.txt requirements.txt
+RUN pip3 install -r requirements.txt
+
+# Copy the rest of the Python application code
+COPY src .
+
+
+# This is NOT ready for production!
+# This is a flask dev server 
+CMD [ "flask", "run", "--host=0.0.0.0"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,14 @@
+# Cheminv 2.0 Backend
+
+## Getting Started
+
+```bash
+# Create a virtual environment
+python -m venv venv
+# Activate the virtual environment
+source venv/bin/activate
+# Install dependencies
+pip install -r requirements.txt
+# Run the application
+flask --app src.app run
+```

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     volumes:
       - ./db:/var/lib/mysql
   cheminv:
+    depends_on:
+      - mysql
     ports:
       - 5000:5000
     environment:

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,5 +1,18 @@
 name: cheminv
 services:
+  cheminv:
+    depends_on:
+      mysql:
+        condition: service_healthy
+    ports:
+      - 5000:5000
+    environment:
+      - MYSQL_USER=${MYSQL_USER}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+      - MYSQL_DATABASE=cheminv
+    build:
+      context: .
+      dockerfile: Dockerfile
   mysql:
     environment:
       - MYSQL_RANDOM_ROOT_PASSWORD=yes
@@ -11,17 +24,9 @@ services:
     image: mysql:latest
     volumes:
       - ./db:/var/lib/mysql
-  cheminv:
-    depends_on:
-      - mysql
-    ports:
-      - 5000:5000
-    environment:
-      - MYSQL_USER=${MYSQL_USER}
-      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
-      - MYSQL_DATABASE=cheminv
-    build:
-      context: .
-      dockerfile: Dockerfile
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      timeout: 20s
+      retries: 10
 
 networks: {}

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,25 @@
+name: cheminv
+services:
+  mysql:
+    environment:
+      - MYSQL_RANDOM_ROOT_PASSWORD=yes
+      - MYSQL_USER=${MYSQL_USER}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+      - MYSQL_DATABASE=cheminv
+    ports:
+      - "3307:3306"
+    image: mysql:latest
+    volumes:
+      - ./db:/var/lib/mysql
+  cheminv:
+    ports:
+      - 5000:5000
+    environment:
+      - MYSQL_USER=${MYSQL_USER}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+      - MYSQL_DATABASE=cheminv
+    build:
+      context: .
+      dockerfile: Dockerfile
+
+networks: {}

--- a/backend/hello.md
+++ b/backend/hello.md
@@ -1,2 +1,0 @@
-# Backend
-I'm a flask project!

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,11 @@
+blinker==1.9.0
+click==8.1.8
+Flask==3.1.0
+Flask-SQLAlchemy==3.1.1
+greenlet==3.1.1
+itsdangerous==2.2.0
+Jinja2==3.1.5
+MarkupSafe==3.0.2
+SQLAlchemy==2.0.37
+typing_extensions==4.12.2
+Werkzeug==3.1.3

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,6 +6,8 @@ greenlet==3.1.1
 itsdangerous==2.2.0
 Jinja2==3.1.5
 MarkupSafe==3.0.2
+mysql-connector-python==9.2.0
+python-dotenv==1.0.1
 SQLAlchemy==2.0.37
 typing_extensions==4.12.2
 Werkzeug==3.1.3

--- a/backend/src/app.py
+++ b/backend/src/app.py
@@ -1,10 +1,40 @@
 from flask import Flask
+from sqlalchemy import URL, Table
+from sqlalchemy.orm import DeclarativeBase
 from flask_sqlalchemy import SQLAlchemy
+from dotenv import load_dotenv
+import os
 
+# HACK: Wait for MySQL to be ready
+import time
+time.sleep(5)
+
+load_dotenv()
 app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = URL.create(
+    drivername="mysql+mysqlconnector",
+    username=os.getenv("MYSQL_USER"),
+    password=os.getenv("MYSQL_PASSWORD"),
+    host="mysql",
+    database=os.getenv("MYSQL_DATABASE")
+)
+db = SQLAlchemy(app)
+
+# There's probably a better way to do this: https://stackoverflow.com/questions/39955521/sqlalchemy-existing-database-query
+class Base(DeclarativeBase):
+    pass
+with app.app_context():
+    class User(Base):
+        __table__ = Table('User', Base.metadata, autoload_with=db.engine)
+
+
 @app.route('/')
 def hello_world():
     return 'Hello World!'
+
+@app.route('/users')
+def get_users():
+    return "<br/>".join([user.User_Name for user in db.session.query(User).all()])
 
 if __name__ == '__main__':
     app.run()

--- a/backend/src/app.py
+++ b/backend/src/app.py
@@ -5,10 +5,6 @@ from flask_sqlalchemy import SQLAlchemy
 from dotenv import load_dotenv
 import os
 
-# HACK: Wait for MySQL to be ready
-import time
-time.sleep(5)
-
 load_dotenv()
 app = Flask(__name__)
 app.config['SQLALCHEMY_DATABASE_URI'] = URL.create(

--- a/backend/src/app.py
+++ b/backend/src/app.py
@@ -1,0 +1,10 @@
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+
+app = Flask(__name__)
+@app.route('/')
+def hello_world():
+    return 'Hello World!'
+
+if __name__ == '__main__':
+    app.run()


### PR DESCRIPTION
This gets the backend talking to the database, although it uses some kinda ugly hacks to make it work. Running `docker compose up -d --build; docker compose logs -f`. 

I copied the database dump we got from the original project into backend and renamed it `database-dump.sql`. I .gitignored it because this is a public repo, and I don't want to share it to the world. 

A command like 
`docker exec -i cheminv-mysql-1 sh -c 'exec mysql -u"$MYSQL_USER" -p"$MYSQL_PASSWORD"' < database-dump.sql` 
will import it into the MySQL database. 

Once the database has been imported, you can bring it down, `docker compose down` and up again, `docker compose up -d --build; docker compose logs -f`. And you should be able to hit [http://localhost:5000/users](http://localhost:5000/users). 

One thing is that building the docker container is kinda slow since it reinstalls the python packages every time. Will work on getting a better development setup later.