### PR TITLE
Implement user permissions

### DIFF
--- a/backend/src/models.py
+++ b/backend/src/models.py
@@ -111,3 +111,29 @@ class Unit(Base):
     )
     # ...and by Inventory.Unit_ID.
     Inventory = relationship("Inventory", back_populates="Unit")
+
+class Permissions(Base):
+    __tablename__ = 'Permissions'
+    
+    Permissions_ID = Column(Integer, primary_key=True, autoincrement=True)
+    Permissions_Name = Column(String(20), nullable=False)
+    Permissions_Description = Column(String(20), nullable=False)
+    
+    # Relationship to User
+    users = relationship("User", back_populates="permissions")
+class User(Base):
+    __tablename__ = 'User'
+    
+    User_ID = Column(Integer, primary_key=True, autoincrement=True)
+    User_Name = Column(String(30), nullable=False, unique=True)
+    Permissions_ID = Column(
+        Integer, 
+        ForeignKey('Permissions.Permissions_ID'), 
+        nullable=False, 
+        index=True
+    )
+    Is_Active = Column(Boolean, nullable=False, default=True)
+    User_Password = Column(String(256), nullable=False)
+    
+    # Relationship to Permissions
+    permissions = relationship("Permissions", back_populates="users")

--- a/backend/src/permission_requirements.py
+++ b/backend/src/permission_requirements.py
@@ -2,10 +2,8 @@
 from functools import wraps
 from flask import session, abort
 from models import db, User, Permissions
-# Make sure you import your database session and User model:
-# from your_app import db
-# from your_app.models import User
 
+# Mostly implemented using ChatGPT
 def require_editor(func):
     @wraps(func)
     def wrapper(*args, **kwargs):

--- a/backend/src/permission_requirements.py
+++ b/backend/src/permission_requirements.py
@@ -1,0 +1,59 @@
+
+from functools import wraps
+from flask import session, abort
+from models import db, User, Permissions
+# Make sure you import your database session and User model:
+# from your_app import db
+# from your_app.models import User
+
+def require_editor(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        # Retrieve the username from the OIDC auth profile in the session
+        profile = session.get("oidc_auth_profile", {})
+        username = profile.get("preferred_username")
+        
+        if not username:
+            # No username found in session; reject the request.
+            abort(403, "Access denied: No user information available.")
+        
+        # Look up the user in the database.
+        user = db.session.query(User).filter_by(User_Name=username).first()
+        if not user:
+            abort(403, "Access denied: User not found.")
+        
+        # Check if the user has admin privileges.
+        # In our permissions, a user with Permissions_ID of 1 has "Full Access".
+        if user.permissions.Permissions_Name != "Editor" and  user.permissions.Permissions_Name != "Full Access":
+            abort(403, "Access denied: Editor or higher privileges required.")
+        
+        # If all checks pass, call the original function.
+        return func(*args, **kwargs)
+    
+    return wrapper
+
+def require_full_access(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        # Retrieve the username from the OIDC auth profile in the session
+        profile = session.get("oidc_auth_profile", {})
+        username = profile.get("preferred_username")
+        
+        if not username:
+            # No username found in session; reject the request.
+            abort(403, "Access denied: No user information available.")
+        
+        # Look up the user in the database.
+        user = db.session.query(User).filter_by(User_Name=username).first()
+        if not user:
+            abort(403, "Access denied: User not found.")
+        
+        # Check if the user has admin privileges.
+        # In our permissions, a user with Permissions_ID of 1 has "Full Access".
+        if user.permissions.Permissions_Name != "Full Access":
+            abort(403, "Access denied: Full access required.")
+        
+        # If all checks pass, call the original function.
+        return func(*args, **kwargs)
+    
+    return wrapper

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -36,7 +36,7 @@ const Navbar = () => {
                 aria-labelledby="navbarDropdown"
               >
                 <li className="dropdown-item">You have {user.access} access</li>
-                {user.access === "admin" ? (
+                {user.access === "Full Access" ? (
                   <li>
                     <a
                       className="dropdown-item"
@@ -51,7 +51,7 @@ const Navbar = () => {
                   <hr className="dropdown-divider" />
                 </li>
                 <li>
-                  <a className="dropdown-item" href="#">
+                  <a className="dropdown-item" href="/logout">
                     Logout
                   </a>
                 </li>

--- a/frontend/src/ManageUsersModal.js
+++ b/frontend/src/ManageUsersModal.js
@@ -87,9 +87,9 @@ export const ManageUsersModal = () => {
               <thead>
                 <tr>
                   <th scope="col">Username</th>
-                  <th scope="col">Student</th>
-                  <th scope="col">Faculty</th>
-                  <th scope="col">Admin</th>
+                  <th scope="col">Visitor</th>
+                  <th scope="col">Editor</th>
+                  <th scope="col">Full Access</th>
                 </tr>
               </thead>
               <tbody>
@@ -104,8 +104,8 @@ export const ManageUsersModal = () => {
                       <input
                         type="radio"
                         name={user.id + "access"}
-                        value="student"
-                        checked={user.access === "student"}
+                        value="Visitor"
+                        checked={user.access === "Visitor"}
                         onChange={(e) => onAccessChange(e, user.id)}
                       />
                     </td>
@@ -113,8 +113,8 @@ export const ManageUsersModal = () => {
                       <input
                         type="radio"
                         name={user.id + "access"}
-                        value="faculty"
-                        checked={user.access === "faculty"}
+                        value="Editor"
+                        checked={user.access === "Editor"}
                         onChange={(e) => onAccessChange(e, user.id)}
                       />
                     </td>
@@ -122,8 +122,8 @@ export const ManageUsersModal = () => {
                       <input
                         type="radio"
                         name={user.id + "access"}
-                        value="admin"
-                        checked={user.access === "admin"}
+                        value="Full Access"
+                        checked={user.access === "Full Access"}
                         onChange={(e) => onAccessChange(e, user.id)}
                       />
                     </td>


### PR DESCRIPTION
I'm not sure the best way to handle this, since it doesn't merge into main. Still, I'd like a second set of eyes on it to make sure it's working, so I'm create a PR to merge into `auth-fixes`. 

This builds on #51, by doing a few things: 
1. Everytime a user signs in with OKTA, it checks whether that user exists in the database and adds them if not. 
2. It implements the api to get the currently signed in user. 
3. It implements the api to get a list of all users
4. It implements an api to update a user's permissions
5. It implements 2 decorator functions for requiring access: 
`@require_editor`: This will return an error if the user is not an Editor or Full Access. This should be added (underneath `@oidc.require_login`)to all database update methods. 
`@require_full_access`: This will return an error if the user does not have Full Access. This is used for all user administration methods. 
